### PR TITLE
Error reading config file when a coordinator is not already set

### DIFF
--- a/WasabiNostr/Pages/Index.razor
+++ b/WasabiNostr/Pages/Index.razor
@@ -11,12 +11,18 @@
 }
 @if (ApplicationState.WasabiConfigDetected is null)
 {
-    <MudButton Disabled="ApplicationState.Loading" Variant="Variant.Filled" Color="Color.Primary" OnClick="() => ApplicationState.DetectWasabi()">Detect Wasabi</MudButton>
+    <MudButton Disabled="ApplicationState.Loading" Variant="Variant.Filled" Color="Color.Primary"
+               OnClick="() => ApplicationState.DetectWasabi()">Detect Wasabi
+    </MudButton>
 }
 else if (ApplicationState.WasabiConfigDetected is false)
 {
-    <MudAlert Severity="Severity.Error" style="overflow-wrap: break-word;" class="mb-1">The Wasabi config file was not detected</MudAlert>
-    <MudButton Disabled="ApplicationState.Loading" Variant="Variant.Filled" Color="Color.Primary" OnClick="() => ApplicationState.DetectWasabi()">Detect Wasabi</MudButton>
+    <MudAlert Severity="Severity.Error" style="overflow-wrap: break-word;" class="mb-1">The Wasabi config file was not
+        detected
+    </MudAlert>
+    <MudButton Disabled="ApplicationState.Loading" Variant="Variant.Filled" Color="Color.Primary"
+               OnClick="() => ApplicationState.DetectWasabi()">Detect Wasabi
+    </MudButton>
 }
 else if (ApplicationState.WasabiConfigDetected is true)
 {
@@ -24,256 +30,289 @@ else if (ApplicationState.WasabiConfigDetected is true)
     @if (ApplicationState.WasabiConfigError)
     {
         <MudAlert Severity="Severity.Error">There was an error reading the Wasabi config file</MudAlert>
-        <MudButton Disabled="ApplicationState.Loading" Variant="Variant.Filled" Color="Color.Primary" OnClick="() => ApplicationState.DetectWasabi()">Detect Wasabi</MudButton>
+        <MudButton Disabled="ApplicationState.Loading" Variant="Variant.Filled" Color="Color.Primary"
+                   OnClick="() => ApplicationState.DetectWasabi()">Detect Wasabi
+        </MudButton>
     }
     else if (ApplicationState.NetworkTypeDetected is not null)
     {
-        <MudAlert Severity="Severity.Success" class="mb-1">You are currently configured to use @ApplicationState.NetworkTypeDetected </MudAlert>
+        <MudAlert Severity="Severity.Success" class="mb-1">You are currently configured to
+            use @ApplicationState.NetworkTypeDetected </MudAlert>
 
         @if (ApplicationState.Coordinator is not null)
         {
-            <MudAlert Severity="Severity.Success" class="mb-1" style="overflow-wrap: break-word;">The Wasabi coordinator is currently set to @ApplicationState.Coordinator </MudAlert>
+            <MudAlert Severity="Severity.Success" class="mb-1" style="overflow-wrap: break-word;">The Wasabi coordinator
+                is currently set to @ApplicationState.Coordinator </MudAlert>
+        }
 
-
-            <MudPaper Outlined="true" Class="pb-0">
-                @if (ApplicationState.Discovering)
-                {
-                    <MudProgressLinear Color="Color.Primary" Indeterminate="true"/>
-                }
-
-
-                <MudList >
-                    <MudListItem>
-                        <MudStack Row="true" Justify="Justify.SpaceBetween">
-
-                            <MudStack Class="flex-grow-1">
-                                @for (var index = 0; index < ApplicationState.Relays.Count; index++)
-                                {
-                                    var currIndex = index;
-                                    @if(ApplicationState.Discovering && ApplicationState.Client is { } composite && Uri.TryCreate(ApplicationState.Relays[index], UriKind.Absolute, out  var relayUri) && composite.States.TryGetValue(relayUri, out var relayState))
-                                    {
-                                        var icon = relayState switch
-                                        {
-                                            WebSocketState.Open => Icons.Material.Filled.CheckCircle,
-                                            WebSocketState.Connecting => Icons.Material.Filled.HourglassTop,
-                                           _ => Icons.Material.Filled.Stop
-                                        };
-                                        
-                                        var color = relayState switch
-                                        {
-                                            WebSocketState.Open => Color.Success,
-                                            WebSocketState.Connecting => Color.Warning,
-                                            _ => Color.Error
-                                        };
-                                        <MudTextField @bind-Value="ApplicationState.Relays[index]" Label="@($"Nostr Relay #{index + 1}")" Variant="Variant.Text" InputType="InputType.Url" Disabled="@(ApplicationState.Loading || ApplicationState.Discovering)" Adornment="Adornment.End" AdornmentIcon="@icon" AdornmentColor="@color" AdornmentAriaLabel="@relayState?.ToString()"></MudTextField>
-                                
-                                    }
-                                    else
-                                    {
-                                        <MudTextField @bind-Value="ApplicationState.Relays[index]" Label="@($"Nostr Relay #{index + 1}")" Variant="Variant.Text" InputType="InputType.Url" Disabled="@(ApplicationState.Loading || ApplicationState.Discovering)" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.RemoveCircle" OnAdornmentClick="() => ApplicationState.Relays.RemoveAt(currIndex)"></MudTextField>
-                                
-                                    }
-                                    
-                                   }
-                                @if (!ApplicationState.Loading && !ApplicationState.Discovering)
-                                {
-                                    <div>
-                                        <MudButton Disabled="ApplicationState.Loading" Variant="Variant.Filled" Color="ApplicationState.Discovering ? Color.Secondary : Color.Primary" OnClick="() => ApplicationState.Relays.Add(string.Empty)">Add relay</MudButton>
-                                    </div>
-                                }
-
-                            </MudStack>
-                            <div>
-                                <MudButton Size="Size.Large" Disabled="ApplicationState.Loading" Variant="Variant.Filled" Color="ApplicationState.Discovering ? Color.Secondary : Color.Primary" OnClick="OnDiscoveryClick">@(ApplicationState.Discovering ? _connectingToRelay ? "Connecting to relay" : "Cancel Discovery" : "Start Discovery")</MudButton>
-                            </div>
-                        </MudStack>
-                    </MudListItem>
-                </MudList>
-            </MudPaper>
-
-            @if (ApplicationState.EventResults is not null)
+        <MudPaper Outlined="true" Class="pb-0">
+            @if (ApplicationState.Discovering)
             {
-                <MudPaper Outlined="true" Class="pb-0 mt-2" Elevation="1">
-                    <MudList >
-                        <MudListSubheader>
-                            Results
-                        </MudListSubheader>
-                        @{
-                            var first = true;
+                <MudProgressLinear Color="Color.Primary" Indeterminate="true"/>
+            }
 
-                            @foreach (var result in ApplicationState.EventResults.ToArray())
+
+            <MudList>
+                <MudListItem>
+                    <MudStack Row="true" Justify="Justify.SpaceBetween">
+
+                        <MudStack Class="flex-grow-1">
+                            @for (var index = 0; index < ApplicationState.Relays.Count; index++)
                             {
-                                var endpoint = result.GetTaggedData(ApplicationState.EndpointTagIdentifier).FirstOrDefault();
-                                if (endpoint is null)
+                                var currIndex = index;
+                                @if (ApplicationState.Discovering && ApplicationState.Client is { } composite && Uri.TryCreate(ApplicationState.Relays[index], UriKind.Absolute, out var relayUri) && composite.States.TryGetValue(relayUri, out var relayState))
                                 {
-                                    continue;
-                                }
+                                    var icon = relayState switch
+                                    {
+                                        WebSocketState.Open => Icons.Material.Filled.CheckCircle,
+                                        WebSocketState.Connecting => Icons.Material.Filled.HourglassTop,
+                                        _ => Icons.Material.Filled.Stop
+                                    };
 
-                                var isCurrent = endpoint == ApplicationState.Coordinator;
-                                if (!first)
+                                    var color = relayState switch
+                                    {
+                                        WebSocketState.Open => Color.Success,
+                                        WebSocketState.Connecting => Color.Warning,
+                                        _ => Color.Error
+                                    };
+                                    <MudTextField @bind-Value="ApplicationState.Relays[index]"
+                                                  Label="@($"Nostr Relay #{index + 1}")" Variant="Variant.Text"
+                                                  InputType="InputType.Url"
+                                                  Disabled="@(ApplicationState.Loading || ApplicationState.Discovering)"
+                                                  Adornment="Adornment.End" AdornmentIcon="@icon"
+                                                  AdornmentColor="@color"
+                                                  AdornmentAriaLabel="@relayState?.ToString()"></MudTextField>
+                                }
+                                else
                                 {
-                                    <MudDivider/>
+                                    <MudTextField @bind-Value="ApplicationState.Relays[index]"
+                                                  Label="@($"Nostr Relay #{index + 1}")" Variant="Variant.Text"
+                                                  InputType="InputType.Url"
+                                                  Disabled="@(ApplicationState.Loading || ApplicationState.Discovering)"
+                                                  Adornment="Adornment.End"
+                                                  AdornmentIcon="@Icons.Material.Filled.RemoveCircle"
+                                                  OnAdornmentClick="() => ApplicationState.Relays.RemoveAt(currIndex)"></MudTextField>
                                 }
-
-                                first = false;
-
-                                <MudListItem  >
-                                    <MudStack Row="true" Justify="Justify.SpaceBetween">
-                                        <MudStack Justify="Justify.Center" Spacing="0" Style="max-width: 75%" >
-                                            <MudText Typo="Typo.body1">@result.Content</MudText>
-                                            <MudText Typo="Typo.body2" Style="overflow-wrap:break-word;">
-                                                @endpoint
-                                            </MudText>
-                                            <MudText Typo="Typo.body2">
-                                                Published @AsTimeAgo(result.CreatedAt.Value)
-                                            </MudText>
-                                        </MudStack>
-                                        <div>
-                                            <MudButtonGroup Color="Color.Primary" Variant="Variant.Filled">
-
-                                                <MudButton Color="@(isCurrent ? Color.Success : Color.Primary)" Disabled="isCurrent || ApplicationState.Loading" OnClick="() => Set(endpoint)">@(isCurrent ? "Current" : "Set")</MudButton>
-                                                <MudButton Color="Color.Secondary" Disabled="ApplicationState.Loading" OnClick="() => OpenParameters(result)">View parameters</MudButton>
-                                            </MudButtonGroup>
-                                        </div>
-                                    </MudStack>
-
-                                </MudListItem>
                             }
-                        }
-                        @if (ApplicationState.Discovering)
+                            @if (!ApplicationState.Loading && !ApplicationState.Discovering)
+                            {
+                                <div>
+                                    <MudButton Disabled="ApplicationState.Loading" Variant="Variant.Filled"
+                                               Color="ApplicationState.Discovering ? Color.Secondary : Color.Primary"
+                                               OnClick="() => ApplicationState.Relays.Add(string.Empty)">Add relay
+                                    </MudButton>
+                                </div>
+                            }
+
+                        </MudStack>
+                        <div>
+                            <MudButton Size="Size.Large" Disabled="ApplicationState.Loading" Variant="Variant.Filled"
+                                       Color="ApplicationState.Discovering ? Color.Secondary : Color.Primary"
+                                       OnClick="OnDiscoveryClick">@(ApplicationState.Discovering ? _connectingToRelay ? "Connecting to relay" : "Cancel Discovery" : "Start Discovery")</MudButton>
+                        </div>
+                    </MudStack>
+                </MudListItem>
+            </MudList>
+        </MudPaper>
+
+        @if (ApplicationState.EventResults is not null)
+        {
+            <MudPaper Outlined="true" Class="pb-0 mt-2" Elevation="1">
+                <MudList>
+                    <MudListSubheader>
+                        Results
+                    </MudListSubheader>
+                    @{
+                        var first = true;
+
+                        @foreach (var result in ApplicationState.EventResults.ToArray())
                         {
+                            var endpoint = result.GetTaggedData(ApplicationState.EndpointTagIdentifier).FirstOrDefault();
+                            if (endpoint is null)
+                            {
+                                continue;
+                            }
+
+                            var isCurrent = endpoint == ApplicationState.Coordinator;
+                            if (!first)
+                            {
+                                <MudDivider/>
+                            }
+
+                            first = false;
+
                             <MudListItem>
-
                                 <MudStack Row="true" Justify="Justify.SpaceBetween">
+                                    <MudStack Justify="Justify.Center" Spacing="0" Style="max-width: 75%">
+                                        <MudText Typo="Typo.body1">@result.Content</MudText>
+                                        <MudText Typo="Typo.body2" Style="overflow-wrap:break-word;">
+                                            @endpoint
+                                        </MudText>
+                                        <MudText Typo="Typo.body2">
+                                            Published @AsTimeAgo(result.CreatedAt.Value)
+                                        </MudText>
+                                    </MudStack>
+                                    <div>
+                                        <MudButtonGroup Color="Color.Primary" Variant="Variant.Filled">
 
-                                    <MudSkeleton SkeletonType="SkeletonType.Rectangle" Animation="Animation.Wave" Height="80px" Width="70%"/>
-                                    <MudSkeleton SkeletonType="SkeletonType.Rectangle" Animation="Animation.Wave" Height="80px" Width="25%"/>
+                                            <MudButton Color="@(isCurrent ? Color.Success : Color.Primary)"
+                                                       Disabled="isCurrent || ApplicationState.Loading"
+                                                       OnClick="() => Set(endpoint)">@(isCurrent ? "Current" : "Set")</MudButton>
+                                            <MudButton Color="Color.Secondary" Disabled="ApplicationState.Loading"
+                                                       OnClick="() => OpenParameters(result)">View parameters
+                                            </MudButton>
+                                        </MudButtonGroup>
+                                    </div>
                                 </MudStack>
+
                             </MudListItem>
                         }
+                    }
+                    @if (ApplicationState.Discovering)
+                    {
+                        <MudListItem>
 
-                    </MudList>
+                            <MudStack Row="true" Justify="Justify.SpaceBetween">
 
-                </MudPaper>
-                <MudDialog IsVisible="@(ApplicationState.ExpandedCoordinator != null)">
-                    <TitleContent>
-                        <MudText Typo="Typo.h6" Inline="true" Style="overflow-wrap: break-word;">
-                            @ApplicationState.ExpandedCoordinator?.result.PublicKey
-                           
+                                <MudSkeleton SkeletonType="SkeletonType.Rectangle" Animation="Animation.Wave"
+                                             Height="80px" Width="70%"/>
+                                <MudSkeleton SkeletonType="SkeletonType.Rectangle" Animation="Animation.Wave"
+                                             Height="80px" Width="25%"/>
+                            </MudStack>
+                        </MudListItem>
+                    }
+
+                </MudList>
+
+            </MudPaper>
+            <MudDialog IsVisible="@(ApplicationState.ExpandedCoordinator != null)">
+                <TitleContent>
+                    <MudText Typo="Typo.h6" Inline="true" Style="overflow-wrap: break-word;">
+                        @ApplicationState.ExpandedCoordinator?.result.PublicKey
+
+                    </MudText>
+                </TitleContent>
+                <DialogContent>
+                    @if (ApplicationState.ExpandedCoordinator is not null)
+                    {
+                        <MudText Typo="Typo.body1">
+                            @ApplicationState.ExpandedCoordinator?.result.Content
                         </MudText>
-                    </TitleContent>
-                    <DialogContent>
-                        @if (ApplicationState.ExpandedCoordinator is not null)
-                        {
-                            <MudText Typo="Typo.body1">
-                                @ApplicationState.ExpandedCoordinator?.result.Content
-                            </MudText>
-                            <MudList >
-                                <MudListSubheader>Last round parameters</MudListSubheader>
-                                <MudListItem>
-                                    <MudStack Row="true" Justify="Justify.SpaceBetween">
-                                        <MudText >
-                                            Minimum inputs
-                                        </MudText>
-                                        <MudText >
-                                            @ApplicationState.ExpandedCoordinator?.roundParameters.minInputCountByRound
-                                        </MudText>
-                                    </MudStack>
-                                </MudListItem>
-                                <MudListItem>
-                                    <MudStack Row="true" Justify="Justify.SpaceBetween">
-                                        <MudText >
-                                            Maximum inputs
-                                        </MudText>
-                                        <MudText >
-                                            @ApplicationState.ExpandedCoordinator?.roundParameters.maxInputCountByRound
-                                        </MudText>
-                                    </MudStack>
-                                </MudListItem>
-                                <MudListItem>
-                                    <MudStack Row="true" Justify="Justify.SpaceBetween">
-                                        <MudText >
-                                            Fee
-                                        </MudText>
-                                        <MudText >
-                                            @(ApplicationState.ExpandedCoordinator?.roundParameters.coordinationFeeRate.rate * 100)% + free under @(ApplicationState.ExpandedCoordinator?.roundParameters.coordinationFeeRate.plebsDontPayThreshold / 100000000m)) BTC + free remixing
-                                        </MudText>
-                                    </MudStack>
-                                </MudListItem>
-                                <MudListItem>
-                                    <MudStack Row="true" Justify="Justify.SpaceBetween">
-                                        <MudText >
-                                            Input registration time
-                                        </MudText>
-                                        <MudText >
-                                            @ApplicationState.ExpandedCoordinator?.roundParameters.standardInputRegistrationTimeout
-                                        </MudText>
-                                    </MudStack>
-                                </MudListItem>
-                                <MudListItem>
-                                    <MudStack Row="true" Justify="Justify.SpaceBetween">
-                                        <MudText >
-                                            Allowed input types
-                                        </MudText>
-                                        <MudText >
-                                            @string.Join(", ", ApplicationState.ExpandedCoordinator.Value.roundParameters.allowedInputTypes.Select(i => (ApplicationState.ScriptType) i))
-                                        </MudText>
-                                    </MudStack>
-                                </MudListItem>
-                                <MudListItem>
-                                    <MudStack Row="true" Justify="Justify.SpaceBetween">
-                                        <MudText >
-                                            Allowed input amounts
-                                        </MudText>
-                                        <MudText >
-                                            @(ApplicationState.ExpandedCoordinator?.roundParameters.allowedInputAmounts.min / 100000000m) - @(ApplicationState.ExpandedCoordinator?.roundParameters.allowedInputAmounts.max / 100000000m) BTC
-                                        </MudText>
-                                    </MudStack>
+                        <MudList>
+                            <MudListSubheader>Last round parameters</MudListSubheader>
+                            <MudListItem>
+                                <MudStack Row="true" Justify="Justify.SpaceBetween">
+                                    <MudText>
+                                        Minimum inputs
+                                    </MudText>
+                                    <MudText>
+                                        @ApplicationState.ExpandedCoordinator?.roundParameters.minInputCountByRound
+                                    </MudText>
+                                </MudStack>
+                            </MudListItem>
+                            <MudListItem>
+                                <MudStack Row="true" Justify="Justify.SpaceBetween">
+                                    <MudText>
+                                        Maximum inputs
+                                    </MudText>
+                                    <MudText>
+                                        @ApplicationState.ExpandedCoordinator?.roundParameters.maxInputCountByRound
+                                    </MudText>
+                                </MudStack>
+                            </MudListItem>
+                            <MudListItem>
+                                <MudStack Row="true" Justify="Justify.SpaceBetween">
+                                    <MudText>
+                                        Fee
+                                    </MudText>
+                                    <MudText>
+                                        @(ApplicationState.ExpandedCoordinator?.roundParameters.coordinationFeeRate.rate * 100)%
+                                        + free
+                                        under @(ApplicationState.ExpandedCoordinator?.roundParameters.coordinationFeeRate.plebsDontPayThreshold / 100000000m))
+                                        BTC + free remixing
+                                    </MudText>
+                                </MudStack>
+                            </MudListItem>
+                            <MudListItem>
+                                <MudStack Row="true" Justify="Justify.SpaceBetween">
+                                    <MudText>
+                                        Input registration time
+                                    </MudText>
+                                    <MudText>
+                                        @ApplicationState.ExpandedCoordinator?.roundParameters.standardInputRegistrationTimeout
+                                    </MudText>
+                                </MudStack>
+                            </MudListItem>
+                            <MudListItem>
+                                <MudStack Row="true" Justify="Justify.SpaceBetween">
+                                    <MudText>
+                                        Allowed input types
+                                    </MudText>
+                                    <MudText>
+                                        @string.Join(", ", ApplicationState.ExpandedCoordinator.Value.roundParameters.allowedInputTypes.Select(i => (ApplicationState.ScriptType)i))
+                                    </MudText>
+                                </MudStack>
+                            </MudListItem>
+                            <MudListItem>
+                                <MudStack Row="true" Justify="Justify.SpaceBetween">
+                                    <MudText>
+                                        Allowed input amounts
+                                    </MudText>
+                                    <MudText>
+                                        @(ApplicationState.ExpandedCoordinator?.roundParameters.allowedInputAmounts.min / 100000000m) - @(ApplicationState.ExpandedCoordinator?.roundParameters.allowedInputAmounts.max / 100000000m) BTC
+                                    </MudText>
+                                </MudStack>
 
-                                </MudListItem>
-                                <MudListItem>
-                                    <MudStack Row="true" Justify="Justify.SpaceBetween">
-                                        <MudText >
-                                            Allowed output types
-                                        </MudText>
-                                        <MudText >
-                                            @string.Join(", ", ApplicationState.ExpandedCoordinator.Value.roundParameters.allowedOutputTypes.Select(i => (ApplicationState.ScriptType) i))
-                                        </MudText>
-                                    </MudStack>
-                                </MudListItem>
-                                <MudListItem>
-                                    <MudStack Row="true" Justify="Justify.SpaceBetween">
-                                        <MudText >
-                                            Allowed output amounts
-                                        </MudText>
-                                        <MudText >
-                                            @(ApplicationState.ExpandedCoordinator?.roundParameters.allowedOutputAmounts.min / 100000000m) - @(ApplicationState.ExpandedCoordinator?.roundParameters.allowedOutputAmounts.max / 100000000m) BTC
-                                        </MudText>
-                                    </MudStack>
+                            </MudListItem>
+                            <MudListItem>
+                                <MudStack Row="true" Justify="Justify.SpaceBetween">
+                                    <MudText>
+                                        Allowed output types
+                                    </MudText>
+                                    <MudText>
+                                        @string.Join(", ", ApplicationState.ExpandedCoordinator.Value.roundParameters.allowedOutputTypes.Select(i => (ApplicationState.ScriptType)i))
+                                    </MudText>
+                                </MudStack>
+                            </MudListItem>
+                            <MudListItem>
+                                <MudStack Row="true" Justify="Justify.SpaceBetween">
+                                    <MudText>
+                                        Allowed output amounts
+                                    </MudText>
+                                    <MudText>
+                                        @(ApplicationState.ExpandedCoordinator?.roundParameters.allowedOutputAmounts.min / 100000000m) - @(ApplicationState.ExpandedCoordinator?.roundParameters.allowedOutputAmounts.max / 100000000m) BTC
+                                    </MudText>
+                                </MudStack>
 
-                                </MudListItem>
-                            </MudList>
-                        }
+                            </MudListItem>
+                        </MudList>
+                    }
 
-                        @* <pre>@JsonSerializer.Serialize(ApplicationState.ExpandedCoordinator?.roundParameters)</pre> *@
-                    </DialogContent>
-                    <DialogActions>
-                        @{
-                            var isCurrent = ApplicationState.ExpandedCoordinator?.result.GetTaggedData(ApplicationState.EndpointTagIdentifier).FirstOrDefault() == ApplicationState.Coordinator;
-                        }
-                        <MudButton Disabled="isCurrent || ApplicationState.Loading" Variant="Variant.Filled" Color="Color.Primary" OnClick="SetFromDialog" Class="px-10">@(isCurrent ? "Current coordinator" : "Set as coordinator")</MudButton>
-                        <MudButton Variant="Variant.Filled" Color="Color.Secondary" OnClick="() => ApplicationState.ExpandedCoordinator = null" Class="px-10">Close</MudButton>
-                    </DialogActions>
-                </MudDialog>
-            }
+                    @* <pre>@JsonSerializer.Serialize(ApplicationState.ExpandedCoordinator?.roundParameters)</pre> *@
+                </DialogContent>
+                <DialogActions>
+                    @{
+                        var isCurrent = ApplicationState.ExpandedCoordinator?.result.GetTaggedData(ApplicationState.EndpointTagIdentifier).FirstOrDefault() == ApplicationState.Coordinator;
+                    }
+                    <MudButton Disabled="isCurrent || ApplicationState.Loading" Variant="Variant.Filled"
+                               Color="Color.Primary" OnClick="SetFromDialog"
+                               Class="px-10">@(isCurrent ? "Current coordinator" : "Set as coordinator")</MudButton>
+                    <MudButton Variant="Variant.Filled" Color="Color.Secondary"
+                               OnClick="() => ApplicationState.ExpandedCoordinator = null" Class="px-10">Close
+                    </MudButton>
+                </DialogActions>
+            </MudDialog>
         }
     }
-    else
-    {
-        <MudAlert Severity="Severity.Error">There was an error detecting the coordinator currently used</MudAlert>
+}
+else
+{
+    <MudAlert Severity="Severity.Error">There was an error detecting the coordinator currently used</MudAlert>
 
-        <MudButton Disabled="ApplicationState.Loading" Variant="Variant.Filled" Color="Color.Primary" OnClick="() => ApplicationState.DetectWasabi()">Detect Wasabi</MudButton>
-    }
+    <MudButton Disabled="ApplicationState.Loading" Variant="Variant.Filled" Color="Color.Primary"
+               OnClick="() => ApplicationState.DetectWasabi()">Detect Wasabi
+    </MudButton>
+}
 }
 
 @code{

--- a/WasabiNostr/State/ApplicationState.cs
+++ b/WasabiNostr/State/ApplicationState.cs
@@ -166,10 +166,6 @@ var options = new []{NetworkTypeDetected.ToLower(), $"{NetworkTypeDetected.ToLow
                     }
 
                     Coordinator = GetCoordinator(config, NetworkTypeDetected);
-                    if (Coordinator is null)
-                    {
-                        WasabiConfigError = true;
-                    }
                 }
             }
             else


### PR DESCRIPTION
Wasabi no longer sets a coordinator by default so this should be allowed to be empty.

fixes #1 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - More accurate Wasabi configuration handling; avoids showing an error when a config exists but no coordinator is set.
- Style
  - Polished relay list with per-relay icons/colors and conditional input adornments.
  - Improved text wrapping and spacing across messages.
  - “Add relay” button now appears only when appropriate (not loading or discovering).
- Refactor
  - Restructured page markup for consistency without altering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->