### PR TITLE
Error reading config file when a coordinator is not already set

### DIFF
--- a/WasabiNostr/Pages/Index.razor
+++ b/WasabiNostr/Pages/Index.razor
@@ -30,12 +30,15 @@ else if (ApplicationState.WasabiConfigDetected is true)
     {
         <MudAlert Severity="Severity.Success" class="mb-1">You are currently configured to use @ApplicationState.NetworkTypeDetected </MudAlert>
 
-        @if (ApplicationState.Coordinator is not null)
+        @if (ApplicationState.Coordinator is not null && ApplicationState.Coordinator != "")
         {
-            <MudAlert Severity="Severity.Success" class="mb-1" style="overflow-wrap: break-word;">The Wasabi coordinator is currently set to @ApplicationState.Coordinator </MudAlert>
+            <MudAlert Severity="Severity.Success" class="mb-1" style="overflow-wrap: break-word;">The Wasabi coordinator
+                is currently set to @ApplicationState.Coordinator </MudAlert>
+        }
 
-
-            <MudPaper Outlined="true" Class="pb-0">
+        if (true)
+        {
+         <MudPaper Outlined="true" Class="pb-0">
                 @if (ApplicationState.Discovering)
                 {
                     <MudProgressLinear Color="Color.Primary" Indeterminate="true"/>

--- a/WasabiNostr/State/ApplicationState.cs
+++ b/WasabiNostr/State/ApplicationState.cs
@@ -123,7 +123,9 @@ var options = new []{NetworkTypeDetected.ToLower(), $"{NetworkTypeDetected.ToLow
 
     private string GetCoordinatorConfigKey(string network)
     {
-        if(!network.EndsWith("net", StringComparison.InvariantCultureIgnoreCase))
+        if (network == "mainnet")
+            network = "";
+        else if(!network.EndsWith("net", StringComparison.InvariantCultureIgnoreCase))
             network += "Net";
         return $"{network}CoordinatorUri";
     }
@@ -166,10 +168,6 @@ var options = new []{NetworkTypeDetected.ToLower(), $"{NetworkTypeDetected.ToLow
                     }
 
                     Coordinator = GetCoordinator(config, NetworkTypeDetected);
-                    if (Coordinator is null)
-                    {
-                        WasabiConfigError = true;
-                    }
                 }
             }
             else


### PR DESCRIPTION
Wasabi no longer sets a coordinator by default so this should be allowed to be empty.

fixes #1 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented false configuration errors by not flagging missing Coordinator in config.
  * Corrected network key generation (including mainnet handling) for more reliable configuration detection.
  * Displayed Coordinator info only when available, avoiding empty or placeholder output.

* **Style**
  * Adjusted Coordinator message layout across two lines for improved readability and wrapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->